### PR TITLE
Use fzf to trim path prefixes

### DIFF
--- a/shell/fzf-scripts.sh
+++ b/shell/fzf-scripts.sh
@@ -19,9 +19,9 @@ vg() {
 gocd() {
     local gorepo
 
-    gorepo="$(find $GOPATH/src -type d -maxdepth 3 -mindepth 1 | awk -F/ '{print $(NF-2)"/"$(NF-1)"/"$(NF)}' | fzf -0 -1)"
+    gorepo="$(find $GOPATH/src -type d -maxdepth 3 -mindepth 1 | fzf -d / --with-nth=-2..)"
     if [[ -n $gorepo ]]; then
-        cd $GOPATH/src/$gorepo
+        cd $gorepo
     fi
 }
 


### PR DESCRIPTION
Previously the enterprise was included in the fzf output window as seen below:

<img width="348" alt="Screen Shot 2021-11-18 at 5 24 09 PM" src="https://user-images.githubusercontent.com/5448017/142506419-10983d0e-0c4b-4550-9dd3-24d763df0777.png">

Now the org is removed in favor of a smaller output:

<img width="254" alt="Screen Shot 2021-11-18 at 5 24 52 PM" src="https://user-images.githubusercontent.com/5448017/142506510-8b059866-139b-476a-a9ef-8ee06adce5c6.png">

The one edge case occurs when there are identical org/repo names in multiple enterprises.
For example: 
- `github.com/tabboud/dotfiles`
- `bitbucket.com/tabboud/dotfiles`

This is an edge case I am willing to deal with but writing down in case this is encountered in the wild.